### PR TITLE
Remove bower install from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-advanced-searchbox",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "A directive for AngularJS providing a advanced visual search box",
   "main": "dist/angular-advanced-searchbox-tpls.js",
   "repository": {
@@ -28,8 +28,14 @@
     "url": "https://github.com/dnauck/angular-advanced-searchbox/issues"
   },
   "homepage": "https://github.com/dnauck/angular-advanced-searchbox",
+  "dependencies": {
+    "angular": "^1.2.28",
+    "jquery": "^2.1.3",
+    "bootstrap": "^3.3.2",
+    "angular-bootstrap": "^0.12.0",
+    "oi.select": "~0.2.19"
+  },
   "devDependencies": {
-    "bower": "^1.3.12",
     "grunt": "^0.4.5",
     "grunt-angular-templates": "^0.5.7",
     "grunt-bump": "^0.1.0",
@@ -40,7 +46,5 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.6.0"
   },
-  "scripts": {
-    "postinstall": "bower install"
-  }
+  "scripts": {}
 }


### PR DESCRIPTION
`npm` shouldn't be running `bower install` during postinstall. We want to get rid of bower as much as possible